### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Aerospike features.conf should be kept secret
+features.conf

--- a/README.md
+++ b/README.md
@@ -83,3 +83,24 @@ $ vault write database/config/aerospike \
     username='vaultadmin' \
     password='reallysecurepassword'
 ```
+
+## Testing
+
+Integration tests can be run against an Aerospike database running in Docker.
+This requires a valid `features.conf` file to be present in the `test/aerospike_config` directory so that
+security features of the Aerospike enterprise edition can be enabled.
+
+Run the Aerospike server with:
+```sh
+docker-compose -f test/docker-compose.yml up
+```
+
+Then the integration tests can be run in a separate shell with:
+```sh
+go test -tags=integration
+```
+
+You can also run the tests against any Aerospike database by specifying the host and admin user credentials:
+```sh
+go test -tags=integration -host=localhost -port=3000 -username=admin -password=admin
+```

--- a/aerospike_integration_test.go
+++ b/aerospike_integration_test.go
@@ -1,0 +1,244 @@
+// +build integration
+
+package aerospike_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	plugin "github.com/G-Research/vault-plugin-database-aerospike"
+	"github.com/aerospike/aerospike-client-go"
+	"github.com/hashicorp/vault/sdk/database/dbplugin"
+)
+
+var testHost *aerospike.Host
+
+var adminClient *aerospike.Client
+
+func TestMain(m *testing.M) {
+	hostName := flag.String("host", "localhost", "Aerospike host to connect to")
+	hostPort := flag.Int("port", 3000, "Port to connect to")
+	adminUsername := flag.String("username", "admin", "admin username for Aerospike database")
+	adminPassword := flag.String("password", "admin", "admin password for Aerospike database")
+	flag.Parse()
+
+	// Set up package variables to be used in tests
+	testHost = aerospike.NewHost(*hostName, *hostPort)
+
+	clientPolicy := aerospike.NewClientPolicy()
+	clientPolicy.User = *adminUsername
+	clientPolicy.Password = *adminPassword
+
+	client, err := aerospike.NewClientWithPolicyAndHost(clientPolicy, testHost)
+	if err != nil {
+		fmt.Printf("Error connecting to aerospike database as admin: %s\n", err)
+		os.Exit(1)
+	}
+	adminClient = client
+
+	// Run tests
+	testStatus := m.Run()
+
+	// Tidy up
+	adminClient.Close()
+
+	os.Exit(testStatus)
+}
+
+func TestInitWithVerification(t *testing.T) {
+	vaultAdminUser, vaultAdminPassword := setupVaultAdmin(t)
+	defer removeVaultAdmin(t, vaultAdminUser)
+
+	aerospike, err := plugin.New()
+	if err != nil {
+		t.Fatalf("Error creating Aerospike plugin: %s", err)
+	}
+	aerospikePlugin := aerospike.(dbplugin.Database)
+	ctx := context.Background()
+	config := getPluginConfig(vaultAdminUser, vaultAdminPassword)
+
+	_, err = aerospikePlugin.Init(ctx, config, true)
+
+	if err != nil {
+		t.Errorf("Error initialising Aerospike plugin: %s", err)
+	}
+}
+
+func TestCreateUserIntegration(t *testing.T) {
+	vaultAdminUser, vaultAdminPassword := setupVaultAdmin(t)
+	defer removeVaultAdmin(t, vaultAdminUser)
+	plugin := getInitialisedPlugin(t, vaultAdminUser, vaultAdminPassword)
+	ctx := context.Background()
+
+	expiration := time.Date(2020, 5, 26, 0, 0, 0, 0, time.UTC)
+	statements := dbplugin.Statements{
+		Creation: []string{`{ "roles": ["read"] }`},
+	}
+	usernameConfig := dbplugin.UsernameConfig{}
+
+	username, password, err := plugin.CreateUser(ctx, statements, usernameConfig, expiration)
+	if err != nil {
+		t.Fatalf("Error creating user: %s", err)
+	}
+
+	verifyUserCanConnect(t, username, password)
+}
+
+func TestSetCredentialsIntegration(t *testing.T) {
+	vaultAdminUser, vaultAdminPassword := setupVaultAdmin(t)
+	defer removeVaultAdmin(t, vaultAdminUser)
+	plugin := getInitialisedPlugin(t, vaultAdminUser, vaultAdminPassword)
+	ctx := context.Background()
+
+	// Create user
+	expiration := time.Date(2020, 5, 26, 0, 0, 0, 0, time.UTC)
+	statements := dbplugin.Statements{
+		Creation: []string{`{ "roles": ["read"] }`},
+	}
+	usernameConfig := dbplugin.UsernameConfig{}
+
+	username, initialPassword, err := plugin.CreateUser(ctx, statements, usernameConfig, expiration)
+	if err != nil {
+		t.Fatalf("Error creating user: %s", err)
+	}
+
+	// Change password
+	newPassword := "new_password"
+	statements = dbplugin.Statements{}
+	user := dbplugin.StaticUserConfig{
+		Username: username,
+		Password: newPassword,
+	}
+
+	_, _, err = plugin.SetCredentials(ctx, statements, user)
+	if err != nil {
+		t.Fatalf("Error setting user credentials: %s", err)
+	}
+
+	verifyUserCanConnect(t, username, newPassword)
+	verifyUserCannotConnect(t, username, initialPassword)
+}
+
+func TestRevokeUserIntegration(t *testing.T) {
+	vaultAdminUser, vaultAdminPassword := setupVaultAdmin(t)
+	defer removeVaultAdmin(t, vaultAdminUser)
+	plugin := getInitialisedPlugin(t, vaultAdminUser, vaultAdminPassword)
+	ctx := context.Background()
+
+	// Create user
+	expiration := time.Date(2020, 5, 26, 0, 0, 0, 0, time.UTC)
+	statements := dbplugin.Statements{
+		Creation: []string{`{ "roles": ["read"] }`},
+	}
+	usernameConfig := dbplugin.UsernameConfig{}
+
+	username, password, err := plugin.CreateUser(ctx, statements, usernameConfig, expiration)
+	if err != nil {
+		t.Fatalf("Error creating user: %s", err)
+	}
+	verifyUserCanConnect(t, username, password)
+
+	// Revoke user
+	statements = dbplugin.Statements{}
+	if err = plugin.RevokeUser(ctx, statements, username); err != nil {
+		t.Fatalf("Error revoking user: %s", err)
+	}
+
+	verifyUserCannotConnect(t, username, password)
+}
+
+func TestRotateRootCredentialsIntegration(t *testing.T) {
+	vaultAdminUser, initialPassword := setupVaultAdmin(t)
+	defer removeVaultAdmin(t, vaultAdminUser)
+	plugin := getInitialisedPlugin(t, vaultAdminUser, initialPassword)
+	ctx := context.Background()
+
+	newConfig, err := plugin.RotateRootCredentials(ctx, []string{})
+	if err != nil {
+		t.Fatalf("Error rotating root credentials: %s", err)
+	}
+	newPassword := newConfig["password"].(string)
+
+	// Verify admin user can connect with new password
+	verifyUserCanConnect(t, vaultAdminUser, newPassword)
+	verifyUserCannotConnect(t, vaultAdminUser, initialPassword)
+
+	// Verify plugin can be re-initialised with the new config
+	// after first closing the existing connection.
+	if err = plugin.Close(); err != nil {
+		t.Fatalf("Error closing plugin connection: %s", err)
+	}
+	_, err = plugin.Init(ctx, newConfig, true)
+	if err != nil {
+		t.Fatalf("Error initialising Aerospike plugin after credential rotation: %s", err)
+	}
+}
+
+func setupVaultAdmin(t *testing.T) (string, string) {
+	vaultAdminUser := "vault_admin"
+	vaultAdminPassword := "super_secret"
+	roles := []string{"user-admin"}
+	if err := adminClient.CreateUser(aerospike.NewAdminPolicy(), vaultAdminUser, vaultAdminPassword, roles); err != nil {
+		t.Fatalf("Error creating vault admin user: %s", err)
+	}
+	return vaultAdminUser, vaultAdminPassword
+}
+
+func removeVaultAdmin(t *testing.T, adminUser string) {
+	if err := adminClient.DropUser(aerospike.NewAdminPolicy(), adminUser); err != nil {
+		t.Errorf("Error dropping vault admin user: %s", err)
+	}
+}
+
+func getInitialisedPlugin(t *testing.T, vaultAdminUser, vaultAdminPassword string) dbplugin.Database {
+	aerospike, err := plugin.New()
+	if err != nil {
+		t.Fatalf("Error creating Aerospike plugin: %s", err)
+	}
+	aerospikePlugin := aerospike.(dbplugin.Database)
+	ctx := context.Background()
+	config := getPluginConfig(vaultAdminUser, vaultAdminPassword)
+
+	_, err = aerospikePlugin.Init(ctx, config, false)
+	if err != nil {
+		t.Fatalf("Error initialising Aerospike plugin: %s", err)
+	}
+	return aerospikePlugin
+}
+
+func verifyUserCanConnect(t *testing.T, username, password string) {
+	clientPolicy := aerospike.NewClientPolicy()
+	clientPolicy.User = username
+	clientPolicy.Password = password
+
+	client, err := aerospike.NewClientWithPolicyAndHost(clientPolicy, testHost)
+	if err != nil {
+		t.Errorf("Could not connect as user %s with password %s: %s", username, password, err)
+	} else {
+		client.Close()
+	}
+}
+
+func verifyUserCannotConnect(t *testing.T, username, password string) {
+	clientPolicy := aerospike.NewClientPolicy()
+	clientPolicy.User = username
+	clientPolicy.Password = password
+
+	client, err := aerospike.NewClientWithPolicyAndHost(clientPolicy, testHost)
+	if err == nil {
+		t.Errorf("Expected user to be invalid but could connect as user %s with password %s", username, password)
+		client.Close()
+	}
+}
+
+func getPluginConfig(vaultAdminUser, vaultAdminPassword string) map[string]interface{} {
+	return map[string]interface{}{
+		"host":     fmt.Sprintf("%s:%d", testHost.Name, testHost.Port),
+		"username": vaultAdminUser,
+		"password": vaultAdminPassword,
+	}
+}

--- a/test/aerospike_config/aerospike.conf
+++ b/test/aerospike_config/aerospike.conf
@@ -1,0 +1,80 @@
+# Aerospike database configuration file.
+
+# This stanza must come first.
+service {
+    user root
+    group root
+    paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
+    pidfile /var/run/aerospike/asd.pid
+#   service-threads 2 # cpu x 5 in 4.7
+#   transaction-queues 2 # obsolete in 4.7
+#   transaction-threads-per-queue 4 # obsolete in 4.7
+    proto-fd-max 15000
+}
+
+logging {
+
+    # Log file must be an absolute path.
+    file /dev/null {
+        context any info
+    }
+
+    # Send log messages to stdout
+    console {
+        context any info
+    }
+}
+
+network {
+    service {
+        address any
+        port 3000
+
+        # Uncomment the following to set the `access-address` parameter to the
+        # IP address of the Docker host. This will the allow the server to correctly
+        # publish the address which applications and other nodes in the cluster to
+        # use when addressing this node.
+        # access-address <IPADDR>
+    }
+
+    heartbeat {
+
+    address any
+        # mesh is used for environments that do not support multicast
+        mode mesh
+        port 3002
+
+        # use asinfo -v 'tip:host=<ADDR>;port=3002' to inform cluster of
+        # other mesh nodes
+
+        interval 150
+        timeout 10
+    }
+
+    fabric {
+        address any
+        port 3001
+    }
+
+    info {
+        address any
+        port 3003
+    }
+}
+
+namespace test {
+    replication-factor 2
+    memory-size 1G
+    default-ttl 30d # 5 days, use 0 to never expire/evict.
+    nsup-period 120
+    # storage-engine memory
+
+    # To use file storage backing, comment out the line above and use the
+    # following lines instead.
+
+    storage-engine device {
+        file /opt/aerospike/data/test.dat
+        filesize 4G
+        data-in-memory true # Store data in memory in addition to file.
+    }
+}

--- a/test/aerospike_config/aerospike.conf
+++ b/test/aerospike_config/aerospike.conf
@@ -6,9 +6,6 @@ service {
     group root
     paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
     pidfile /var/run/aerospike/asd.pid
-#   service-threads 2 # cpu x 5 in 4.7
-#   transaction-queues 2 # obsolete in 4.7
-#   transaction-threads-per-queue 4 # obsolete in 4.7
     proto-fd-max 15000
     feature-key-file /opt/aerospike/etc/features.conf
 }
@@ -18,7 +15,6 @@ security {
 }
 
 logging {
-
     # Log file must be an absolute path.
     file /dev/null {
         context any info
@@ -34,24 +30,12 @@ network {
     service {
         address any
         port 3000
-
-        # Uncomment the following to set the `access-address` parameter to the
-        # IP address of the Docker host. This will the allow the server to correctly
-        # publish the address which applications and other nodes in the cluster to
-        # use when addressing this node.
-        # access-address <IPADDR>
     }
 
     heartbeat {
-
-    address any
-        # mesh is used for environments that do not support multicast
-        mode mesh
+        address any
+        mode mesh # mesh is used for environments that do not support multicast
         port 3002
-
-        # use asinfo -v 'tip:host=<ADDR>;port=3002' to inform cluster of
-        # other mesh nodes
-
         interval 150
         timeout 10
     }
@@ -67,15 +51,12 @@ network {
     }
 }
 
+# At least one namespace must be configured
 namespace test {
     replication-factor 2
     memory-size 1G
-    default-ttl 30d # 5 days, use 0 to never expire/evict.
+    default-ttl 30d # use 0 to never expire/evict.
     nsup-period 120
-    # storage-engine memory
-
-    # To use file storage backing, comment out the line above and use the
-    # following lines instead.
 
     storage-engine device {
         file /opt/aerospike/data/test.dat

--- a/test/aerospike_config/aerospike.conf
+++ b/test/aerospike_config/aerospike.conf
@@ -10,6 +10,11 @@ service {
 #   transaction-queues 2 # obsolete in 4.7
 #   transaction-threads-per-queue 4 # obsolete in 4.7
     proto-fd-max 15000
+    feature-key-file /opt/aerospike/etc/features.conf
+}
+
+security {
+    enable-security true
 }
 
 logging {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.0"
 
 services:
   aerospike:
-    image: aerospike/aerospike-server:5.0.0.3
+    image: aerospike/aerospike-server-enterprise:5.0.0.3
     command: ["--config-file", "/opt/aerospike/etc/aerospike.conf"]
     volumes:
       - "./aerospike_config:/opt/aerospike/etc"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.0"
+
+services:
+  aerospike:
+    image: aerospike/aerospike-server:5.0.0.3
+    command: ["--config-file", "/opt/aerospike/etc/aerospike.conf"]
+    volumes:
+      - "./aerospike_config:/opt/aerospike/etc"
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
Adds integration tests that run against an actual Aerospike database.

This will require some fixes to work with the changes in #2 if that was to be merged as is (will need to pass the client factory when creating the plugin).