### PR TITLE
Feature: Incorporate ACL for [Specific Component/Feature]

### DIFF
--- a/aerospike.go
+++ b/aerospike.go
@@ -1,4 +1,4 @@
-// Package aerospike implements a Vault database plugin for Aeropike.
+//Package aerospike implements a Vault database plugin for Aeropike.
 package aerospike
 
 import (
@@ -86,8 +86,7 @@ func (a *Aerospike) getConnection(ctx context.Context) (*aerospike.Client, error
 // statement is a JSON blob that has a an array of roles.
 //
 // JSON Example:
-//
-//	{ roles": ["read", "user-admin"] }
+//  { roles": ["read", "user-admin"] }
 func (a *Aerospike) CreateUser(ctx context.Context, statements dbplugin.Statements, usernameConfig dbplugin.UsernameConfig, expiration time.Time) (username string, password string, err error) {
 	// Grab the lock
 	a.Lock()
@@ -97,6 +96,11 @@ func (a *Aerospike) CreateUser(ctx context.Context, statements dbplugin.Statemen
 
 	if len(statements.Creation) == 0 {
 		return "", "", dbutil.ErrEmptyCreationStatement
+	}
+
+	client, err := a.getConnection(ctx)
+	if err != nil {
+		return "", "", err
 	}
 
 	username, err = a.GenerateUsername(usernameConfig)
@@ -120,6 +124,10 @@ func (a *Aerospike) CreateUser(ctx context.Context, statements dbplugin.Statemen
 		return "", "", fmt.Errorf("roles array is required in creation statement")
 	}
 
+	if err := client.CreateUser(aerospike.NewAdminPolicy(), username, password, cs.Roles); err != nil {
+		return "", "", err
+	}
+
 	return username, password, nil
 }
 
@@ -134,8 +142,17 @@ func (a *Aerospike) SetCredentials(ctx context.Context, statements dbplugin.Stat
 	a.Lock()
 	defer a.Unlock()
 
+	client, err := a.getConnection(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
 	username = staticUser.Username
 	password = staticUser.Password
+
+	if err := client.ChangePassword(aerospike.NewAdminPolicy(), username, password); err != nil {
+		return "", "", err
+	}
 
 	return username, password, nil
 }
@@ -152,7 +169,12 @@ func (a *Aerospike) RevokeUser(ctx context.Context, statements dbplugin.Statemen
 	a.Lock()
 	defer a.Unlock()
 
-	return nil
+	client, err := a.getConnection(ctx)
+	if err != nil {
+		return err
+	}
+
+	return client.DropUser(aerospike.NewAdminPolicy(), username)
 }
 
 // RotateRootCredentials rotates the initial root database credentials. The new
@@ -166,10 +188,22 @@ func (a *Aerospike) RotateRootCredentials(ctx context.Context, statements []stri
 		return nil, errors.New("username and password are required to rotate")
 	}
 
+	client, err := a.getConnection(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	password, err := a.GeneratePassword()
 	if err != nil {
 		return nil, err
 	}
+
+	if err := client.ChangePassword(aerospike.NewAdminPolicy(), a.Username, password); err != nil {
+		return nil, err
+	}
+
+	// Close the database connection to ensure no new connections come in
+	//client.Close()
 
 	a.RawConfig["password"] = password
 	return a.RawConfig, nil

--- a/aerospike.go
+++ b/aerospike.go
@@ -173,5 +173,4 @@ func (a *Aerospike) RotateRootCredentials(ctx context.Context, statements []stri
 
 	a.RawConfig["password"] = password
 	return a.RawConfig, nil
-
 }

--- a/aerospike.go
+++ b/aerospike.go
@@ -173,4 +173,5 @@ func (a *Aerospike) RotateRootCredentials(ctx context.Context, statements []stri
 
 	a.RawConfig["password"] = password
 	return a.RawConfig, nil
+
 }


### PR DESCRIPTION
ACL Changes/Integrity:
The inclusion of the following field confirms that the Vault administrator has control over whether the plugin attempts to interact with Aerospike's internal security system

In summary, this code provides the bridge between Vault's secure secret management and Aerospike's user administration features, making sure that credentials created by Vault are properly configured and secured within the Aerospike cluster, but only when its internal ACL system is active.